### PR TITLE
Fix crawler header encoding and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,16 @@ All processed texts are stripped of common Dutch judge signatures, clerical line
 Install dependencies:
 
 ```bash
-pip install datasets huggingface_hub requests
+pip install -r requirements.txt
+```
+
+### Running the crawler
+
+The crawler respects the publisher's rate limit by sending one request per second and uses an ASCII-only `User-Agent` header to avoid encoding issues.
+
+```bash
+python crawl_rechtspraak.py \
+  --since "$(date -u -d '1 hour ago' +'%Y-%m-%dT%H:%M:%S')" \
+  --out data/rs_sync.jsonl \
+  --push organisation/rechtspraak-nl
+```

--- a/crawl_rechtspraak.py
+++ b/crawl_rechtspraak.py
@@ -28,8 +28,8 @@ import datasets            # pip install datasets
 BASE_SEARCH_URL = "https://data.rechtspraak.nl/uitspraken/zoeken"
 BASE_CONTENT_URL = "https://data.rechtspraak.nl/uitspraken/content"
 USER_AGENT = (
-    "RechtspraakCrawler/0.5 (orga@example.org)  "
-    "— respects server‑load advice; one request per second."
+    "RechtspraakCrawler/0.5 (orga@example.org) "
+    "- respects server-load advice; one request per second."
 )
 MAX_PER_REQUEST = 1_000                          # hard limit set by API :contentReference[oaicite:0]{index=0}
 REQUEST_PAUSE_SEC = 1.05                         # “Don’t hammer the server” :contentReference[oaicite:1]{index=1}


### PR DESCRIPTION
## Summary
- ensure User-Agent string only contains ASCII characters
- expand README usage instructions and close code block

## Testing
- `python -m py_compile crawl_rechtspraak.py merge_and_push.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685408f732a08329951a42c4503eb419