### PR TITLE
Fix relative paths in merge script

### DIFF
--- a/merge_and_push.py
+++ b/merge_and_push.py
@@ -11,7 +11,8 @@ import datasets  # pip install datasets
 from tqdm import tqdm
 
 # Settings
-DATA_DIR = Path("data")
+HERE = Path(__file__).resolve().parent
+DATA_DIR = HERE / "data"
 OUTPUT_PATH = DATA_DIR / "rechtspraak_merged.jsonl"
 HUB_REPO = "vGassen/dutch-court-cases-rechtspraak" 
 


### PR DESCRIPTION
## Summary
- ensure `merge_and_push.py` resolves the `data` directory relative to the script location

## Testing
- `python -m py_compile crawl_rechtspraak.py merge_and_push.py`

------
https://chatgpt.com/codex/tasks/task_e_685416c73b0c8329bb33a7f4b8ed4cd1