### PR TITLE
Improve crawler reliability

### DIFF
--- a/.github/workflows/rechtspraak_sync.yml
+++ b/.github/workflows/rechtspraak_sync.yml
@@ -1,6 +1,8 @@
 name: Rechtspraak Sync (Every 30min)
 
 on:
+  schedule:
+    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Creative Commons Zero v1.0 Universal
+====================================
+
+This work is dedicated to the public domain under the CC0 1.0 Universal license.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+For full details see <https://creativecommons.org/publicdomain/zero/1.0/>.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To retrieve complete cases, two API calls are required:
 - **Access**: Public
 - **Publisher**: Raad voor de Rechtspraak (Rijk)
 - **Contact**: [kennissystemen@rechtspraak.nl](mailto:kennissystemen@rechtspraak.nl)
+- **Code license**: see [LICENSE](LICENSE)
 
 Source catalog: [data.overheid.nl](https://data.overheid.nl)
 
@@ -63,4 +64,22 @@ python crawl_rechtspraak.py \
   --since "$(date -u -d '1 hour ago' +'%Y-%m-%dT%H:%M:%S')" \
   --out data/rs_sync.jsonl \
   --push organisation/rechtspraak-nl
+```
+
+### Resuming and sharding
+
+Use `--state-file` to log processed ECLI identifiers so that a subsequent run
+can skip them:
+
+```bash
+python crawl_rechtspraak.py --state-file crawl.log --out data/part.jsonl
+```
+
+For large backfills the crawl can be split across multiple shards using
+`--shard-index` and `--num-shards`:
+
+```bash
+# Two shards running in parallel
+python crawl_rechtspraak.py --shard-index 0 --num-shards 2 --out data/s0.jsonl
+python crawl_rechtspraak.py --shard-index 1 --num-shards 2 --out data/s1.jsonl
 ```

--- a/crawl_rechtspraak.py
+++ b/crawl_rechtspraak.py
@@ -31,8 +31,8 @@ USER_AGENT = (
     "RechtspraakCrawler/0.5 (orga@example.org) "
     "- respects server-load advice; one request per second."
 )
-MAX_PER_REQUEST = 1_000                          # hard limit set by API :contentReference[oaicite:0]{index=0}
-REQUEST_PAUSE_SEC = 1.05                         # “Don’t hammer the server” :contentReference[oaicite:1]{index=1}
+MAX_PER_REQUEST = 1_000                          # hard limit set by API
+REQUEST_PAUSE_SEC = 1.05                         # "Don't hammer the server"
 NAME_RE = re.compile(
     r"""
     \b
@@ -44,6 +44,15 @@ NAME_RE = re.compile(
     re.VERBOSE,
 )
 SIGNATURE_RE = re.compile(r"(?i)(?:Deze uitspraak is ondertekend).*?$", re.S)
+
+# Load list of judge names that should be scrubbed from the text
+JUDGE_NAMES_PATH = Path(__file__).with_name("judge_names.json")
+if JUDGE_NAMES_PATH.exists():
+    with JUDGE_NAMES_PATH.open(encoding="utf-8") as jf:
+        _judge_names = json.load(jf)
+    JUDGE_RE = re.compile("|".join(re.escape(n) for n in _judge_names), re.I)
+else:
+    JUDGE_RE = re.compile(r"^$")  # matches nothing when file missing
 
 ###############################################################################
 # HELPER FUNCTIONS
@@ -67,6 +76,8 @@ def _atom_page(
 def _iter_eclis(
     session: requests.Session,
     modified_from: Optional[dt.datetime] = None,
+    shard_index: int = 0,
+    num_shards: int = 1,
 ) -> Iterable[str]:
     """
     Yields every ECLI that has *documents* (return=DOC) updated since
@@ -77,6 +88,7 @@ def _iter_eclis(
         base_params["modified"] = modified_from.isoformat()
 
     offset = 0
+    counter = 0
     while True:
         params = {**base_params, "from": str(offset)}
         feed = _atom_page(session, **params)
@@ -86,8 +98,11 @@ def _iter_eclis(
         for entry in feed.entries:
             # skip placeholder entries (deleted="ecli"/"doc")
             if getattr(entry, "deleted", False):
+                counter += 1
                 continue
-            yield entry.id
+            if counter % num_shards == shard_index:
+                yield entry.id
+            counter += 1
 
         offset += len(feed.entries)
         time.sleep(REQUEST_PAUSE_SEC)
@@ -115,6 +130,7 @@ def _scrub_xml(xml_text: str) -> Dict[str, Any]:
     text = "\n".join(paras)
 
     # Scrub
+    text = JUDGE_RE.sub("[RECHTER]", text)
     text = NAME_RE.sub("[PERSOON]", text)
     text = SIGNATURE_RE.sub("", text).strip()
 
@@ -128,6 +144,9 @@ def crawl(
     out_file: Path,
     modified_from: Optional[str | dt.datetime] = None,
     push_to_hub: Optional[str] = None,
+    state_file: Optional[Path] = None,
+    shard_index: int = 0,
+    num_shards: int = 1,
 ) -> None:
     """
     Parameters
@@ -140,26 +159,51 @@ def crawl(
         If None, *all* available decisions (~800 k) will be downloaded.
     push_to_hub : str | None
         If set, the dataset will be pushed to this HF repo (e.g. 'org/rs_nl').
+    state_file : Path | None
+        Optional file used to log processed ECLI identifiers so that a crawl can
+        resume when run again.
+    shard_index : int
+        Index of this shard (0-based) when splitting the crawl.
+    num_shards : int
+        Total number of shards for parallel crawling.
     """
     if isinstance(modified_from, str):
         modified_from = dt.datetime.fromisoformat(modified_from)
     session = _session()
     out_file.parent.mkdir(parents=True, exist_ok=True)
 
+    processed: set[str] = set()
+    state_fh = None
+    if state_file:
+        if state_file.exists():
+            with state_file.open() as sf:
+                processed = {line.strip() for line in sf if line.strip()}
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_fh = state_file.open("a")
+
     with out_file.open("w", encoding="utf‑8") as fh, tqdm(
         total=None, unit="doc", desc="Decisions"
     ) as pbar:
-        for ecli in _iter_eclis(session, modified_from):
+        for ecli in _iter_eclis(session, modified_from, shard_index, num_shards):
+            if ecli in processed:
+                pbar.update()
+                continue
             try:
                 xml = _download_xml(session, ecli)
                 record = _scrub_xml(xml)
                 fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+                if state_fh:
+                    state_fh.write(ecli + "\n")
+                    state_fh.flush()
                 pbar.update()
             except Exception as exc:
                 # log & continue
                 print(f"[warn] {ecli}: {exc}")
 
             time.sleep(REQUEST_PAUSE_SEC)
+
+    if state_fh:
+        state_fh.close()
 
     if push_to_hub:
         if out_file.stat().st_size == 0:
@@ -195,5 +239,25 @@ if __name__ == "__main__":
         default=None,
         help="💡 Optional HuggingFace repo name to push the dataset.",
     )
+    ap.add_argument(
+        "--state-file",
+        type=Path,
+        default=None,
+        help="File to store processed ECLI identifiers for resuming",
+    )
+    ap.add_argument("--shard-index", type=int, default=0, help="Which shard to run")
+    ap.add_argument(
+        "--num-shards",
+        type=int,
+        default=1,
+        help="Total number of shards for parallel crawling",
+    )
     args = ap.parse_args()
-    crawl(args.out, modified_from=args.since, push_to_hub=args.push)
+    crawl(
+        args.out,
+        modified_from=args.since,
+        push_to_hub=args.push,
+        state_file=args.state_file,
+        shard_index=args.shard_index,
+        num_shards=args.num_shards,
+    )


### PR DESCRIPTION
## Summary
- schedule the sync workflow every 30 minutes
- scrub judge names from XML
- support resumable crawling via a state file
- add sharding options
- document resuming and sharding
- add CC0 LICENSE

## Testing
- `python -m py_compile crawl_rechtspraak.py merge_and_push.py`

------
https://chatgpt.com/codex/tasks/task_e_68553e52ea2083299cb180d95f0d8592