### PR TITLE
Fix default repo for merge script

### DIFF
--- a/.github/workflows/rechtspraak_sync.yml
+++ b/.github/workflows/rechtspraak_sync.yml
@@ -31,7 +31,7 @@ jobs:
           python crawl_rechtspraak.py \
             --since "$(date -u -d '1 hour ago' +'%Y-%m-%dT%H:%M:%S')" \
             --out data/rs_sync.jsonl \
-            --push organisation/rechtspraak-nl
+            --push vGassen/dutch-court-cases-rechtspraak
 
   merge-and-push:
     needs: sync-uitspraken

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The crawler respects the publisher's rate limit by sending one request per secon
 python crawl_rechtspraak.py \
   --since "$(date -u -d '1 hour ago' +'%Y-%m-%dT%H:%M:%S')" \
   --out data/rs_sync.jsonl \
-  --push organisation/rechtspraak-nl
+  --push vGassen/dutch-court-cases-rechtspraak
 ```
 
 ### Resuming and sharding

--- a/merge_and_push.py
+++ b/merge_and_push.py
@@ -7,8 +7,11 @@ Example
 -------
 python merge_and_push.py \
        --pattern "data/rs_*.jsonl" \
-       --repo   "organisation/rechtspraak-nl" \
+       --repo   "vGassen/dutch-court-cases-rechtspraak" \
        --token  $HF_TOKEN
+
+If ``--repo`` is omitted, ``vGassen/dutch-court-cases-rechtspraak`` will be
+used or the value of the ``HF_REPO`` environment variable if set.
 """
 from __future__ import annotations
 
@@ -20,6 +23,9 @@ from typing import List
 
 from datasets import Dataset, DatasetDict, concatenate_datasets, load_dataset
 from huggingface_hub import HfApi, HfFolder
+
+
+DEFAULT_REPO = "vGassen/dutch-court-cases-rechtspraak"
 
 
 # --------------------------------------------------------------------------- #
@@ -67,7 +73,11 @@ def push_dataset(ds: Dataset, repo_id: str, token: str | None) -> None:
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--pattern", default="data/*.jsonl", help="Glob of crawl shards")
-    p.add_argument("--repo", required=True, help="Hub repo name, e.g. org/rechtspraak-nl")
+    p.add_argument(
+        "--repo",
+        default=os.getenv("HF_REPO", DEFAULT_REPO),
+        help="Hub repo name (default: %(default)s)",
+    )
     p.add_argument(
         "--token",
         help="HF access token. "


### PR DESCRIPTION
## Summary
- set `vGassen/dutch-court-cases-rechtspraak` as the default repo for `merge_and_push.py`
- update README instructions
- update workflow push target

## Testing
- `python -m py_compile merge_and_push.py`
- `pip install -r requirements.txt` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68554aae93b08329bf62fb9daa7eff03