### PR TITLE
Fix dataset merge workflow

### DIFF
--- a/.github/workflows/rechtspraak_sync.yml
+++ b/.github/workflows/rechtspraak_sync.yml
@@ -32,6 +32,12 @@ jobs:
             --since "$(date -u -d '1 hour ago' +'%Y-%m-%dT%H:%M:%S')" \
             --out data/rs_sync.jsonl \
             --push vGassen/dutch-court-cases-rechtspraak
+      - name: Upload crawl shard
+        uses: actions/upload-artifact@v3
+        with:
+          name: crawl-shard
+          path: data/rs_sync.jsonl
+
 
   merge-and-push:
     needs: sync-uitspraken
@@ -51,6 +57,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Download crawl shard
+        uses: actions/download-artifact@v3
+        with:
+          name: crawl-shard
+          path: data
+
 
       - name: Run merge_and_push.py
         env:


### PR DESCRIPTION
## Summary
- upload data artifact between workflow jobs
- download artifact before merging dataset files

## Testing
- `python -m py_compile merge_and_push.py crawl_rechtspraak.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685567a182308329af7f81231c95492b