### PR TITLE
Improve Rechtspraak crawler paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ python crawl_rechtspraak.py \
 ```
 
 A minimal example using an internal `checkpoint.json` for automatic resumption
-and uploading is available via `rechtspraak_crawler.py`:
+and uploading is available via `rechtspraak_crawler.py`. Pass `--resume` to
+continue an interrupted crawl:
 
 ```bash
 HF_TOKEN=your_token python rechtspraak_crawler.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tqdm>=4.66.0
 datasets>=2.18.0
 huggingface_hub>=0.21.0
 regex>=2023.12.25
+pytest>=7.4.0

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "rechtspraak_crawler", Path(__file__).resolve().parents[1] / "rechtspraak_crawler.py"
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)  # type: ignore
+
+fetch_ecli_page = module.fetch_ecli_page
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.content = text.encode()
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+def test_fetch_ecli_page(monkeypatch):
+    xml_feed = """
+    <feed xmlns='http://www.w3.org/2005/Atom'>
+        <entry><id>E1</id><updated>2020-01-01T00:00:00</updated></entry>
+        <entry><id>E2</id><updated>2020-01-02T00:00:00</updated></entry>
+    </feed>
+    """
+
+    called_params = {}
+
+    def fake_get(url, params=None, timeout=None):
+        called_params.update(params)
+        return DummyResponse(xml_feed)
+
+    session = SimpleNamespace(get=fake_get)
+    batch = fetch_ecli_page(session, None, 0)
+    assert len(batch) == 2
+    assert batch[0]["ecli"] == "E1"
+    assert called_params["from"] == 0
+


### PR DESCRIPTION
## Summary
- implement offset-based paging with `max` and `from`
- store only `last_published` and a resumable offset in the checkpoint
- upload each page immediately
- add `--resume` option and logging
- document resume flag in README
- include minimal paging test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685af67ea68883299f1dac473807f18a