### PR TITLE
Enable offset and date filtering for Rechtspraak crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ continue an interrupted crawl:
 HF_TOKEN=your_token python rechtspraak_crawler.py
 ```
 
+Additional flags let you control the crawl window or pagination offset:
+
+```bash
+HF_TOKEN=your_token python rechtspraak_crawler.py \
+  --max-items 1000 \
+  --start-offset 0 \
+  --start-date 2020-01-01 \
+  --end-date 2020-12-31 \
+  --delay 1.0
+```
+
 ### Resuming and sharding
 
 Use `--state-file` to log processed ECLI identifiers so that a subsequent run


### PR DESCRIPTION
## Summary
- support paging offset and date filtering
- expose max items and delay CLI options
- document new options in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685c0a6c56208329b2df678276f0781f