### PR TITLE
Add judge and gemachtigde name scrubber

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import json
 import datetime
 from tqdm import tqdm
 
-from . import api_client, parser, config, state_manager, uploader
+from . import api_client, parser, config, state_manager, uploader, name_scrubber
 
 def process_and_save(metadata_iterator, output_file_path):
     """
@@ -27,6 +27,8 @@ def process_and_save(metadata_iterator, output_file_path):
 
             # 2. Parse XML to get text
             full_text = parser.parse_ruling_xml(xml_content)
+            full_text = name_scrubber.scrub_judge_names(full_text)
+            full_text = name_scrubber.scrub_gemachtigde_names(full_text)
 
             # 3. Format and save
             record = {

--- a/src/name_scrubber.py
+++ b/src/name_scrubber.py
@@ -1,0 +1,33 @@
+import json
+import re
+from pathlib import Path
+
+# Load judge names once
+_JUDGE_NAMES_FILE = Path(__file__).parent / "judge_names.json"
+try:
+    with open(_JUDGE_NAMES_FILE, "r", encoding="utf-8") as f:
+        _JUDGE_NAMES = json.load(f)
+except Exception:
+    _JUDGE_NAMES = []
+
+# Pre-compile regex patterns for faster replacement
+_JUDGE_PATTERNS = [re.compile(re.escape(name), re.IGNORECASE) for name in _JUDGE_NAMES]
+
+# Simple gemachtigde pattern: match a few tokens following the keyword
+_GEMACHTIGDE_PATTERN = re.compile(
+    r"(?i)(gemachtigde[^\n]{0,10}(?:mr\.\s*)?)((?:[A-Za-zÀ-ÖØ-öø-ÿ.'`-]+\s*){1,5})"
+)
+
+def scrub_judge_names(text: str) -> str:
+    """Replace known judge names with the placeholder 'NAAM'."""
+    if not text:
+        return text
+    for pattern in _JUDGE_PATTERNS:
+        text = pattern.sub("NAAM", text)
+    return text
+
+def scrub_gemachtigde_names(text: str) -> str:
+    """Replace names following 'gemachtigde' with 'NAAM'."""
+    if not text:
+        return text
+    return _GEMACHTIGDE_PATTERN.sub(lambda m: f"{m.group(1)}NAAM", text)


### PR DESCRIPTION
## Summary
- implement name_scrubber module
- scrub judge names based on JSON list
- scrub gemachtigde names with a simple regex
- integrate scrubbing into main pipeline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e61549c1483298404959a94857449