### PR TITLE
Add crawler permissions and reliability updates

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   run-crawler:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     
     # Environment variables available to all steps
@@ -62,6 +64,11 @@ jobs:
         # Save crawler progress for manual or scheduled backfills
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         run: |
+          if [ ! -f data/crawler_state.json ]; then
+            echo "State file not found. Nothing to commit."
+            exit 0
+          fi
+
           # Check if the state file has been modified
           if [[ -z $(git status -s data/crawler_state.json) ]]; then
             echo "State file not modified. No commit needed."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Python tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pip install -r requirements.txt
 
 ### Running the crawler
 
-The crawler respects the publisher's rate limit by sending one request per second and uses an ASCII-only `User-Agent` header to avoid encoding issues. Because over 800k decisions are available, long crawls can be resumed via the state file described below.
+The crawler respects the publisher's rate limit by sending one request per second and uses an ASCII-only `User-Agent` header to avoid encoding issues. The delay can be adjusted via the `REQUEST_DELAY_SEC` environment variable. Because over 800k decisions are available, long crawls can be resumed via the state file described below.
 
 ```bash
 python crawl_rechtspraak.py \
@@ -107,6 +107,8 @@ python crawl_rechtspraak.py --shard-index 1 --num-shards 2 --out data/s1.jsonl
 
 `BACKFILL_MAX_ITEMS` controls how many historical cases are processed in a
 single run. By default it is set to `10000`.
+
+`REQUEST_DELAY_SEC` defines the delay between API requests. It defaults to `1.0` second.
 
 ```bash
 BACKFILL_MAX_ITEMS=5000 python -m src.main backfill

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -6,6 +6,8 @@ from typing import Iterator, Dict, Any, Optional
 
 from . import config
 
+HEADERS = {"User-Agent": config.USER_AGENT}
+
 def get_metadata_batch(start_from: int = 0, modified_since: Optional[str] = None) -> Iterator[Dict[str, Any]]:
     """
     Fetches a paginated stream of metadata entries from the /zoeken endpoint.
@@ -30,8 +32,14 @@ def get_metadata_batch(start_from: int = 0, modified_since: Optional[str] = None
             params['modified'] = modified_since
 
         try:
-            response = requests.get(config.BASE_API_URL, params=params, timeout=60)
+            response = requests.get(
+                config.BASE_API_URL,
+                params=params,
+                headers=HEADERS,
+                timeout=60,
+            )
             response.raise_for_status()
+            time.sleep(config.REQUEST_DELAY_SEC)
 
             feed = response.text
             if not feed or "<entry>" not in feed:
@@ -73,8 +81,14 @@ def get_ruling_content(ecli_id: str, max_retries: int = 3) -> Optional[str]:
     params = {'id': ecli_id}
     for attempt in range(max_retries):
         try:
-            response = requests.get(config.CONTENT_API_URL, params=params, timeout=60)
+            response = requests.get(
+                config.CONTENT_API_URL,
+                params=params,
+                headers=HEADERS,
+                timeout=60,
+            )
             response.raise_for_status()
+            time.sleep(config.REQUEST_DELAY_SEC)
             return response.text
         except requests.exceptions.RequestException as e:
             wait = 2 ** attempt

--- a/src/config.py
+++ b/src/config.py
@@ -4,10 +4,14 @@ import os
 from pathlib import Path
 
 # --- API Configuration ---
-BASE_API_URL = "http://data.rechtspraak.nl/uitspraken/zoeken"
-CONTENT_API_URL = "http://data.rechtspraak.nl/uitspraken/content"
-DEEPLINK_URL_PREFIX = "http://deeplink.rechtspraak.nl/uitspraak?id="
+BASE_API_URL = "https://data.rechtspraak.nl/uitspraken/zoeken"
+CONTENT_API_URL = "https://data.rechtspraak.nl/uitspraken/content"
+DEEPLINK_URL_PREFIX = "https://deeplink.rechtspraak.nl/uitspraak?id="
 API_MAX_RESULTS_PER_PAGE = 1000  # As per API documentation
+
+# User-Agent header and request throttling
+USER_AGENT = "rechtspraak-crawler/1.0"
+REQUEST_DELAY_SEC = float(os.getenv("REQUEST_DELAY_SEC", "1.0"))
 
 # --- Local File Paths ---
 CRAWLER_DIR = Path(__file__).parent.parent

--- a/tests/test_name_scrubber.py
+++ b/tests/test_name_scrubber.py
@@ -1,0 +1,10 @@
+from src.name_scrubber import scrub_judge_names, scrub_gemachtigde_names
+
+def test_scrub_judge_names():
+    text = 'De rechter is dhr. mr. B.G.L. van der Aa.'
+    assert scrub_judge_names(text) == 'De rechter is NAAM.'
+
+def test_scrub_gemachtigde_names():
+    text = 'Verschenen voor de gemachtigde mr. Jan Jansen.'
+    cleaned = scrub_gemachtigde_names(text)
+    assert 'NAAM' in cleaned

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,20 @@
+from src.parser import parse_ruling_xml
+
+def test_parse_uitspraak():
+    xml = (
+        '<rs:root xmlns:rs="http://www.rechtspraak.nl/schema/rechtspraak-1.0">'
+        '<rs:uitspraak><p>Hello <b>world</b>.</p></rs:uitspraak>'
+        '</rs:root>'
+    )
+    assert parse_ruling_xml(xml) == 'Hello world.'
+
+def test_parse_conclusie():
+    xml = (
+        '<rs:root xmlns:rs="http://www.rechtspraak.nl/schema/rechtspraak-1.0">'
+        '<rs:conclusie>Test</rs:conclusie>'
+        '</rs:root>'
+    )
+    assert parse_ruling_xml(xml) == 'Test'
+
+def test_invalid_xml():
+    assert parse_ruling_xml('<invalid>') == ''


### PR DESCRIPTION
## Summary
- allow workflow to push with `contents: write`
- avoid workflow failure when state file is missing
- enforce 1 second delay and custom user-agent in API client
- switch API endpoints to HTTPS
- document request delay environment variable
- add unit tests and workflow to run them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685edab21b4c8329b53794adbe31a381