### PR TITLE
Fix backlog upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ single run. By default it is set to `10000`.
 ```bash
 BACKFILL_MAX_ITEMS=5000 python -m src.main backfill
 ```
+
+Historical backfills write results to `data/rechtspraak_backlog_<start>_<timestamp>.jsonl`.
+Each run creates a new file so that uploads to the Hugging Face dataset do not
+overwrite earlier batches.

--- a/src/main.py
+++ b/src/main.py
@@ -65,7 +65,8 @@ def backfill():
     """
     print("🚀 Starting historical backfill...")
     start_index = state_manager.load_state()
-    output_file = config.DATA_DIR / "rechtspraak_backlog.jsonl"
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_file = config.DATA_DIR / f"rechtspraak_backlog_{start_index}_{timestamp}.jsonl"
 
     metadata_stream = api_client.get_metadata_batch(start_from=start_index)
 


### PR DESCRIPTION
## Summary
- create a unique backlog filename each run
- document the new backlog naming in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686385e7a0bc832997b60b0b97184c97