### PR TITLE
Update workflow and README for crawler.py

### DIFF
--- a/.github/workflows/daily-ingest.yml
+++ b/.github/workflows/daily-ingest.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-      - name: Run daily ingest
-        run: python rechtspraak_ingest.py
+      - name: Run crawler
+        run: python crawler.py

--- a/crawler.py
+++ b/crawler.py
@@ -13,6 +13,7 @@ from huggingface_hub import login
 HF_DATASET_ID = "vGassen/dutch-court-cases-rechtspraak"
 ALL_ECLIS_FILE = "all_rechtspraak_eclis.json"  # File to store all discovered ECLIs
 CHECKPOINT_FILE = "processed_eclis.json"      # File to track processed ECLIs
+JUDGES_FILE = "judge_names.json"              # List of judge names for scrubbing
 BATCH_SIZE = 100                              # Number of records to process and upload in one batch
 MAX_RECORDS_PER_RUN = 5000                    # Safety limit for a single execution of the script
 REQUEST_DELAY_S = 1.0                         # Delay between API requests to be polite


### PR DESCRIPTION
## Summary
- run `crawler.py` in the daily ingest workflow
- clarify anonymisation logic in README and update usage examples
- define `JUDGES_FILE` constant in `crawler.py`

## Testing
- `python -m py_compile crawler.py rechtspraak_ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_68683204265c8329b315f8db8765c63f