### PR TITLE
Fix bs4 dependency for crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+The requirements file includes `beautifulsoup4` which is needed for HTML/XML
+parsing in the crawler.
+
 ### Running the crawler
 
 The crawler respects the publisher's rate limit by sending one request per second and uses an ASCII-only `User-Agent` header to avoid encoding issues. The delay can be adjusted via the `REQUEST_DELAY_SEC` environment variable. Because over 800k decisions are available, long crawls can be resumed via the state file described below.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 tqdm
 huggingface_hub
 datasets
+
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add missing `beautifulsoup4` requirement
- document the dependency in the README

## Testing
- `python -m py_compile crawler.py rechtspraak_ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_686833b5313883298658d981243b66a5