### PR TITLE
Handle missing ECLI list automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The crawler respects the publisher's rate limit by sending one request per secon
 HF_TOKEN=your_token python crawler.py
 ```
 
+On the first run the script checks for an existing `all_rechtspraak_eclis.json`
+file containing the ECLI index. If it is missing, an initial discovery pass is
+executed automatically to create it before processing any cases.
+
 The crawler maintains a checkpoint so interrupted runs can resume automatically.
 You can limit the number of items or adjust the API delay using environment
 variables documented in the script.

--- a/crawler.py
+++ b/crawler.py
@@ -173,9 +173,16 @@ def main():
     # Load ECLI lists
     all_eclis = load_json_set(ALL_ECLIS_FILE)
     if not all_eclis:
-        logging.error(f"ECLI list file '{ALL_ECLIS_FILE}' is empty or not found.")
-        logging.info("Please run the discovery function first: `fetch_all_eclis()`")
-        return
+        logging.info(
+            f"ECLI list file '{ALL_ECLIS_FILE}' is empty or not found. Running initial discovery..."
+        )
+        fetch_all_eclis()
+        all_eclis = load_json_set(ALL_ECLIS_FILE)
+        if not all_eclis:
+            logging.error(
+                f"Failed to populate '{ALL_ECLIS_FILE}' after discovery attempt."
+            )
+            return
 
     processed_eclis = load_json_set(CHECKPOINT_FILE)
     eclis_to_process = sorted(list(all_eclis - processed_eclis))


### PR DESCRIPTION
## Summary
- detect missing `all_rechtspraak_eclis.json` in main
- automatically run `fetch_all_eclis()` to create it on first run
- document automatic discovery behavior in README

## Testing
- `python -m py_compile crawler.py rechtspraak_ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_686836f4a4788329860bb78c376fd17e