### PR TITLE
Fix search query for Rechtspraak crawler

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -83,6 +83,7 @@ def fetch_all_eclis():
                 "from": start_index,
                 "return": "META",
                 "type": doc_type,
+                "q": "*",  # required as of mid-2024
             }
             logging.info(f"Fetching {doc_type} ECLIs from index {start_index}...")
             try:


### PR DESCRIPTION
## Summary
- fix Rechtspraak search by including `q=*`

## Testing
- `python -m py_compile crawler.py rechtspraak_ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_686901e9dc2083299170d358a3388354