### PR TITLE
Fix ECLI formatting

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -143,7 +143,7 @@ def discover_eclis_batch(limit: int = DISCOVERY_BATCH_LIMIT) -> int:
                     logging.info(f"No more entries for {doc_type}.")
                     break
 
-                batch_eclis = {entry.id.text for entry in entries if entry.id}
+                batch_eclis = {entry.id.text.replace('%', ':') for entry in entries if entry.id}
                 newly_found = len(batch_eclis - discovered_eclis)
                 discovered_eclis.update(batch_eclis)
                 total_new += newly_found
@@ -186,6 +186,7 @@ def process_ecli(ecli: str, judge_names: set) -> dict | None:
     """Fetches, parses, and anonymizes the content for a single ECLI."""
     content_url = "https://data.rechtspraak.nl/uitspraak"
     try:
+        ecli = ecli.replace('%', ':')
         response = get_with_retry(content_url, params={"id": ecli})
         soup = BeautifulSoup(response.content, "xml")
 

--- a/rechtspraak_ingest.py
+++ b/rechtspraak_ingest.py
@@ -62,7 +62,7 @@ def fetch_eclis(start=0, limit=2000):
                 start_tag = xml.find("<id>")
                 end_tag = xml.find("</id>")
                 if start_tag != -1 and end_tag != -1:
-                    eclis.append(xml[start_tag + 4:end_tag])
+                    eclis.append(xml[start_tag + 4:end_tag].replace('%', ':'))
             processed += params["max"]
             params["from"] += params["max"]
             time.sleep(1)
@@ -73,7 +73,7 @@ def fetch_eclis(start=0, limit=2000):
 def fetch_content(ecli):
     url = "https://data.rechtspraak.nl/uitspraken/content"
     try:
-        resp = get_with_retry(url, params={"id": ecli})
+        resp = get_with_retry(url, params={"id": ecli.replace('%', ':')})
         return resp.text
     except requests.RequestException as exc:
         print(f"Failed to fetch {ecli}: {exc}")
@@ -125,11 +125,12 @@ def main():
         batch = eclis_to_process[i:i+BATCH_SIZE]
         batch_data = []
         for ecli in batch:
-            content = fetch_content(ecli)
+            clean_ecli = ecli.replace('%', ':')
+            content = fetch_content(clean_ecli)
             if not content or len(content) < 100: continue
             scrubbed = scrub_names(content, judge_names, name_regex)
             batch_data.append({
-                "URL": f"https://deeplink.rechtspraak.nl/uitspraak?id={ecli}",
+                "URL": f"https://deeplink.rechtspraak.nl/uitspraak?id={clean_ecli}",
                 "Content": scrubbed,
                 "Source": "Rechtspraak"
             })


### PR DESCRIPTION
## Summary
- normalize ECLI IDs when discovering and fetching
- ensure ingest script decodes `%` back to `:` before API calls and URLs

## Testing
- `python -m py_compile crawler.py rechtspraak_ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_686a22f174b08329b01543510cef3a36