### PR TITLE
Fix incremental dataset uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ If a run is interrupted simply execute `python crawler.py` again and it will
 continue where it left off.
 Uploaded records include a `batch` field. The last uploaded batch number is
 stored in `batch_state.json` so subsequent runs continue numbering sequentially.
+Each processed batch is uploaded as its own `data/batch_<n>.jsonl` file on the
+Hugging Face dataset, ensuring earlier batches remain available.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
- add `batch` metadata to uploaded records
- upload each batch as a new JSONL file using `HfApi.upload_file`
- document batch files in README

## Testing
- `python -m py_compile crawler.py`

------
https://chatgpt.com/codex/tasks/task_b_686bfbf6ce34832f90e093111fee3747